### PR TITLE
adjust DatabaseWrapperMixin to make sure the base get_new_connection is called when creating a new connection

### DIFF
--- a/django_db_geventpool/backends/base.py
+++ b/django_db_geventpool/backends/base.py
@@ -30,7 +30,7 @@ class DatabaseWrapperMixin(object):
             return self._pool
         with connection_pools_lock:
             if self.alias not in connection_pools:
-                self._pool = self.pool_class(**self.get_connection_params())
+                self._pool = self.pool_class(super(), **self.get_connection_params(), connect=lambda parent, **kw: parent.get_new_connection(conn_params=kw))
                 connection_pools[self.alias] = self._pool
             else:
                 self._pool = connection_pools[self.alias]

--- a/runtests_psycopg2.py
+++ b/runtests_psycopg2.py
@@ -43,6 +43,6 @@ django.setup()
 
 test_runner = DiscoverRunner(verbosity=2)
 
-failures = test_runner.run_tests(["tests"])
+failures = test_runner.run_tests(["tests.tests"])
 if failures:
     sys.exit(failures)

--- a/runtests_psycopg2_gis.py
+++ b/runtests_psycopg2_gis.py
@@ -43,6 +43,6 @@ django.setup()
 
 test_runner = DiscoverRunner(verbosity=2)
 
-failures = test_runner.run_tests(["tests"])
+failures = test_runner.run_tests(["tests.tests", "tests.tests_gis"])
 if failures:
     sys.exit(failures)

--- a/runtests_psycopg3_gis.py
+++ b/runtests_psycopg3_gis.py
@@ -13,7 +13,7 @@ settings.configure(
     DEBUG=True,
     DATABASES={
         "default": {
-            "ENGINE": "django_db_geventpool.backends.postgresql_psycopg3",
+            "ENGINE": "django_db_geventpool.backends.postgis",
             "NAME": "test",
             "USER": "postgres",
             "PASSWORD": "postgres",
@@ -32,6 +32,6 @@ django.setup()
 
 test_runner = DiscoverRunner(verbosity=2)
 
-failures = test_runner.run_tests(["tests.tests"])
+failures = test_runner.run_tests(["tests.tests", "tests.tests_gis"])
 if failures:
     sys.exit(failures)

--- a/tests/tests_gis.py
+++ b/tests/tests_gis.py
@@ -1,0 +1,26 @@
+from django.contrib.gis.db import models
+from django.contrib.gis.geos import Point
+from django.db import connection
+from django.test import SimpleTestCase
+
+from .models import TestModel
+
+class GisTestModel(TestModel):
+    pointfield = models.PointField()
+
+class GisModelTest(SimpleTestCase):
+    databases = {"default"}
+
+    def test_gis_connection(self):
+        data = {
+            "charfield": "testing save",
+            "jsonfield": {"test": "value"},
+            "pointfield": Point(0, 0),
+        }
+
+        with connection.pool.get() as connection.connection:
+            pk = GisTestModel.objects.create(**data).pk
+
+            obj = GisTestModel.objects.get(pk=pk)
+            for key in data.keys():
+                self.assertEqual(data[key], getattr(obj, key))

--- a/tox.ini
+++ b/tox.ini
@@ -8,9 +8,9 @@ python =
 
 [tox]
 envlist =
-  py3{8,9,10,11,12}-dj{32,42}-pg{is,2}
-  py3{8,9,10,11,12}-dj{42}-pg{3}
-  py3{10,11,12}-dj{50}-pg{is,2,3}
+  py3{8,9,10,11,12}-dj{32,42}-pg{is2,2}
+  py3{8,9,10,11,12}-dj{42}-pg{is3,3}
+  py3{10,11,12}-dj{50}-pg{is2,2,is3,3}
 
 [testenv]
 deps =
@@ -19,11 +19,13 @@ deps =
   dj32: django~=3.2
   dj42: django~=4.2
   dj50: django~=5.0
-  pgis: psycopg2-binary
+  pgis2: psycopg2-binary
   pg2: psycopg2-binary
+  pgis3: psycopg[binary,pool]
   pg3: psycopg[binary,pool]
 
 commands =
-  pgis: python -Wall runtests_psycopg2_gis.py
+  pgis2: python -Wall runtests_psycopg2_gis.py
   pg2: python -Wall runtests_psycopg2.py
+  pgis3: python -Wall runtests_psycopg3_gis.py
   pg3: python -Wall runtests_psycopg3.py


### PR DESCRIPTION
This is needed for psycopg3 because the base postgis DatabaseWrapper from django registers geometry adapters in the get_new_connection call